### PR TITLE
fix for error when source is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ mov-cli-rs "south park" -f -s 21 -e 3 -q 720p
 - [x] Playlist extract argument
 - [x] Media FZF menu
 - [x] Quality argument
-- [ ] Finish README
+- [x] Finish README
 - [ ] Download argument
 - [ ] More source resolving
 - [ ] More player support


### PR DESCRIPTION
copied from code comment:
```
this'll handle the json decoding safely, unsure why but the safe handling does not cover this? tested with alternate API URL and got 'failed - panicked` for every source, does reqwest's serde feature somehow unintentionally pass by this?
ps: this happened because flixhq is down, braflix seems to have some way to check what's up and not up, need to implement that at some point, would also give a chance to make it prettier
```
simply returned empty and printed failed when the wrapped json data is an error before it gets unwrapped